### PR TITLE
Add beads-sync-protocol for autonomous ticket sync to main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,11 @@ run commands, or make any changes directly. You NEVER use the Edit, Write, Noteb
       <rule>Tickets track dependencies via the "dependencies" field with type "blocks"</rule>
       <rule>A ticket is ready when all its blocking dependencies are closed</rule>
       <rule>Never close a ticket without completing all workflow phases</rule>
+      <rule>
+        When tickets are created or closed, run the beads-sync-protocol
+        (see docs/.starter_pack_docs/workflows/WORKFLOW_ENTRY.xml) to push changes to main.
+        This is autonomous — no human gate. Only .beads/ files go on BEADS/ sync branches.
+      </rule>
     </rules>
   </beads>
 

--- a/docs/.starter_pack_docs/workflows/BEADS.xml
+++ b/docs/.starter_pack_docs/workflows/BEADS.xml
@@ -69,6 +69,12 @@
     <type name="chore" branch-prefix="CHORE/">Maintenance — deps, tooling, config</type>
     <type name="epic" branch-prefix="EPIC/">Large feature with subtasks</type>
 
+    <system-prefix name="BEADS/" purpose="beads-sync-protocol">
+      Reserved for automated beads ticket sync branches. Not tied to an issue type.
+      Created by the beads-sync-protocol (see WORKFLOW_ENTRY.xml) when ticket changes
+      need to reach main. These branches are auto-merged and deleted — never manual.
+    </system-prefix>
+
     <custom>
       Custom types can be added via: bd config set types.custom "typename1,typename2"
       Custom types use the type name uppercased as the branch prefix (e.g. SPIKE/).

--- a/docs/.starter_pack_docs/workflows/WORKFLOW_ENTRY.xml
+++ b/docs/.starter_pack_docs/workflows/WORKFLOW_ENTRY.xml
@@ -40,7 +40,8 @@
         </action>
         <action>Present the full ticket breakdown to the human for approval before starting any work</action>
         <gate>BLOCKED — Do not proceed. Human approval of the ticket breakdown is required before starting any child ticket work.</gate>
-        <action>Once approved, pick the first ready ticket (bd ready) and proceed to PLANNING workflow</action>
+        <action>Once approved, run the beads-sync-protocol to push ticket changes to main (see below)</action>
+        <action>Pick the first ready ticket (bd ready) and proceed to PLANNING workflow</action>
       </actions>
       <status-message>executing ENTRY/SPEC_FILE — decomposing spec into tickets</status-message>
     </entry>
@@ -57,6 +58,7 @@
           - Use the human's request as the description basis
         </action>
         <action>Confirm the ticket with the human: "Created {ticket-id}: {title}. Proceeding with this."</action>
+        <action>Run the beads-sync-protocol to push ticket changes to main (see below)</action>
         <action>Proceed to PLANNING workflow with the new ticket</action>
       </actions>
       <rule>
@@ -121,6 +123,45 @@
       - AD_HOC_REQUEST → TRUNK_BASED (unless the orchestrator determines during PLANNING/INTAKE that it should be an epic)
     </selection>
   </branching-strategy>
+
+  <beads-sync-protocol>
+    <!--
+      Reusable protocol for syncing beads ticket changes to main. This ensures
+      ticket creation and closing events reach main so the GitHub Actions beads-sync
+      workflow triggers. This protocol is autonomous — no human gate required.
+
+      Triggers:
+      - After ticket creation (ENTRY/SPEC_FILE, ENTRY/AD_HOC_REQUEST)
+      - After child ticket close (IMPLEMENTATION/HANDOFF in FEATURE_BRANCHING)
+      - After final ticket close (PR/SUBMIT)
+
+      Does NOT trigger for:
+      - Sub-task comment updates (bd comment) — these stay local until the feature branch merges
+      - Status changes to in_progress — low-priority metadata
+    -->
+
+    <steps>
+      <step order="1">Note the current branch (or "main" if not on a branch yet)</step>
+      <step order="2">Switch to main and pull latest: git checkout main && git pull</step>
+      <step order="3">Create a short-lived sync branch: git checkout -b BEADS/sync-{ticket-id}</step>
+      <step order="4">Run bd sync to export changes to .beads/issues.jsonl</step>
+      <step order="5">Stage only .beads/ files: git add .beads/</step>
+      <step order="6">Commit: "{ticket-id}: sync beads tickets"</step>
+      <step order="7">Push: git push -u origin BEADS/sync-{ticket-id}</step>
+      <step order="8">Create and auto-merge PR: gh pr create --title "beads: sync tickets" --body "Automated beads sync" && gh pr merge --merge --delete-branch</step>
+      <step order="9">Switch back to the previous branch: git checkout {previous-branch}</step>
+      <step order="10">Pull main into the working branch if on a feature/epic branch: git merge main (to pick up the beads changes)</step>
+    </steps>
+
+    <rules>
+      <rule>Only .beads/ files go on BEADS/ branches — never code, never docs</rule>
+      <rule>This is fully autonomous — no human approval needed</rule>
+      <rule>If the merge into the working branch has conflicts (unlikely for .beads/ files), stop and ask the human</rule>
+      <rule>The orchestrator delegates this to a submitter agent (light tier) — it never runs git commands itself</rule>
+    </rules>
+
+    <status-message>executing BEADS_SYNC — syncing ticket changes to main</status-message>
+  </beads-sync-protocol>
 
   <scope-enforcement>
     <!--

--- a/docs/.starter_pack_docs/workflows/WORKFLOW_IMPLEMENTATION.xml
+++ b/docs/.starter_pack_docs/workflows/WORKFLOW_IMPLEMENTATION.xml
@@ -128,7 +128,8 @@
     <phase name="HANDOFF" order="7">
       <description>
         TRUNK_BASED: proceed to the DOCS workflow.
-        FEATURE_BRANCHING: close the child ticket and return to the orchestrator.
+        FEATURE_BRANCHING: close the child ticket, then run the beads-sync-protocol
+        (see WORKFLOW_ENTRY.xml) to push the ticket close to main. Return to the orchestrator.
         The orchestrator picks the next ready child ticket, or proceeds to DOCS if all children are complete.
       </description>
       <status-message>executing IMPLEMENTATION/HANDOFF on {ticket-id} — transitioning to DOCS</status-message>

--- a/docs/.starter_pack_docs/workflows/WORKFLOW_PR.xml
+++ b/docs/.starter_pack_docs/workflows/WORKFLOW_PR.xml
@@ -75,6 +75,12 @@
           closed during their individual workflow cycles). If any children are still open,
           flag this to the orchestrator before closing.
         </action>
+        <action>
+          After closing the ticket, run the beads-sync-protocol (see WORKFLOW_ENTRY.xml)
+          to push the ticket close to main. Note: if the PR itself is merging to main,
+          the beads changes will be included in the merge — only run the sync protocol
+          if the ticket close happened after the PR was already merged.
+        </action>
         <action>Report the PR URL back to the orchestrator</action>
       </actions>
 


### PR DESCRIPTION
## Summary

- Adds a reusable beads-sync-protocol that syncs ticket changes to main via auto-merged BEADS/ branches
- Triggers on ticket creation (ENTRY) and ticket closing (IMPLEMENTATION/HANDOFF, PR/SUBMIT)
- Fully autonomous - no human gate needed for ticket metadata
- Finding from kanban validation test (sp-or1)

## Changes

| File | Change |
|------|--------|
| docs/.starter_pack_docs/workflows/WORKFLOW_ENTRY.xml | New beads-sync-protocol section, referenced from SPEC_FILE and AD_HOC_REQUEST |
| docs/.starter_pack_docs/workflows/WORKFLOW_IMPLEMENTATION.xml | Reference protocol in HANDOFF for feature branching child closes |
| docs/.starter_pack_docs/workflows/WORKFLOW_PR.xml | Reference protocol in SUBMIT after ticket close |
| docs/.starter_pack_docs/workflows/BEADS.xml | Add BEADS/ system branch prefix |
| CLAUDE.md | Add sync rule to beads section |

## Ticket

sp-or1

---
Generated by Claude Code orchestrator