### PR TITLE
Fix nightly orchestration: agent-routing and dispatch-mode

### DIFF
--- a/.starterpack/agent_instructions/behaviors/autonomous-nightly.xml
+++ b/.starterpack/agent_instructions/behaviors/autonomous-nightly.xml
@@ -89,9 +89,10 @@
     </rule>
 
     <rule order="2">
-      Find the GitHub issue number for the ticket. Look in .beads/github-map.json
-      for a mapping from the beads ticket ID to the GitHub issue number. If no
-      mapping exists, search GitHub issues for the ticket title:
+      The GitHub issue number was resolved during the DETECT phase. Use that
+      issue number directly. If for any reason it is not available, fall back
+      to searching .beads/github-map.json for a mapping from the beads ticket
+      ID to the GitHub issue number, or search GitHub issues:
         gh issue list --search "{ticket title}" --json number,title --limit 5
       If no matching issue is found, create one:
         gh issue create --title "{ticket title}" --body "Linked to beads ticket {id}"

--- a/.starterpack/agent_instructions/lifecycle/nightly-autonomous-run.xml
+++ b/.starterpack/agent_instructions/lifecycle/nightly-autonomous-run.xml
@@ -1,9 +1,10 @@
 <lifecycle name="NIGHTLY_AUTONOMOUS_RUN">
 
   <summary>
-    On-demand pre-flight gate for tickets labeled autonomously-nightly. Acts as an
-    alternative entry point that assesses ticket completeness, then either activates
-    autonomous mode on the standard workflow or posts clarifying questions and exits.
+    On-demand pre-flight gate for GitHub issues labeled autonomously-nightly. Scans
+    open issues, correlates with beads tickets (creating one if needed), assesses
+    completeness, then either activates autonomous mode on the standard workflow
+    or posts clarifying questions and exits.
   </summary>
 
   <uses-behavior name="autonomous-nightly" />
@@ -16,36 +17,96 @@
           v
       [Phase 1: DETECT]
           |
-          +~~ label NOT present ~~> [EXIT — lifecycle does not apply]
+          +~~ no GitHub issues labeled autonomously-nightly ~~> [EXIT — nothing to process]
           |
           +~~ command failure ~~> [EXIT — report error]
           |
-          +~~ label present ~~> [Phase 2: ASSESS]
-                                    |
-                                    +~~ INCOMPLETE ~~> [Phase 3: ROUTE_INCOMPLETE] ~~> [EXIT — questions posted]
-                                    |
-                                    +~~ COMPLETE ~~> [Phase 4: ROUTE_COMPLETE] ~~> [ENTRY lifecycle, autonomous mode]
+          +~~ issue found, beads ticket exists ~~> [Phase 3: ASSESS]
+          |
+          +~~ issue found, NO beads ticket ~~> [Phase 2: MIGRATE_ISSUE]
+                                                    |
+                                                    +~~ success ~~> [Phase 3: ASSESS]
+                                                    |
+                                                    +~~ failure ~~> [EXIT — report error]
+
+      [Phase 3: ASSESS]
+          |
+          +~~ INCOMPLETE ~~> [Phase 4: ROUTE_INCOMPLETE] ~~> [EXIT — questions posted]
+          |
+          +~~ COMPLETE ~~> [Phase 5: ROUTE_COMPLETE] ~~> [ENTRY lifecycle, autonomous mode]
     -->
 
     <phase name="DETECT" order="1">
       <actor>Orchestrator (reasoning tier)</actor>
       <actions>
-        <action>Read the ticket using "bd show {id}".</action>
         <action>
-          Run "bd label list {id}" to retrieve the ticket's labels.
-          If the command fails (error, unrecognized subcommand), report the
-          error and exit. Do not treat a command failure as "label not present."
+          Query GitHub for open issues labeled "autonomously-nightly":
+            gh issue list --label "autonomously-nightly" --state open --json number,title,body,labels,createdAt --limit 20
+          If the command fails, report the error and exit.
+          If no issues are returned, report that no issues are labeled for nightly processing and exit.
         </action>
         <action>
-          If the command succeeds but the "autonomously-nightly" label is NOT
-          in the results, report that this lifecycle does not apply and exit.
+          Select the oldest issue by createdAt (one-at-a-time processing).
+          Store the issue number, title, and body for subsequent phases.
+        </action>
+        <action>
+          Check .beads/github-map.json for a beads ticket mapped to this GitHub issue number.
+          (Reverse lookup: scan values for the issue number, return the matching key/ticket ID.)
+        </action>
+        <action>
+          If a mapped beads ticket exists:
+            Read the ticket with "bd show {ticket-id}" to confirm it still exists and is valid.
+            If valid, proceed to ASSESS with this ticket.
+            If the ticket no longer exists (bd show fails), treat as unmapped and fall through.
+        </action>
+        <action>
+          If NO mapped beads ticket exists:
+            Proceed to MIGRATE_ISSUE phase to create one.
         </action>
       </actions>
-      <on-success>Label confirmed — proceed to ASSESS.</on-success>
-      <on-failure>Exit — command error or label not present.</on-failure>
+      <on-success>Ticket correlation established — proceed to ASSESS or MIGRATE_ISSUE.</on-success>
+      <on-failure>Exit — no labeled issues found or command error.</on-failure>
     </phase>
 
-    <phase name="ASSESS" order="2">
+    <phase name="MIGRATE_ISSUE" order="2">
+      <actor>Orchestrator (reasoning tier)</actor>
+      <actions>
+        <action>
+          Determine the ticket type from the GitHub issue labels:
+            - If labeled "bug" → type = bug
+            - If labeled "enhancement" or "feature" → type = feature
+            - Otherwise → type = task
+        </action>
+        <action>
+          Create a beads ticket from the GitHub issue content:
+            bd create --type {type} --title "{issue title}" --description "{issue body}"
+          Store the new ticket ID.
+        </action>
+        <action>
+          Add the label to the new beads ticket:
+            bd label add {ticket-id} autonomously-nightly
+        </action>
+        <action>
+          Update .beads/github-map.json to record the mapping:
+            {ticket-id} → {github-issue-number}
+          Use jq or python3 to safely merge the new entry into the existing JSON file.
+        </action>
+        <action>
+          Close the GitHub issue with a migration comment:
+            gh issue close {number} --comment "This issue is now tracked as beads ticket {ticket-id}. Work will proceed via the starterpack orchestration workflow."
+        </action>
+        <action>
+          Commit and push the beads metadata:
+            git add .beads/
+            git commit -m "{ticket-id}: migrate GitHub issue #{number} to beads"
+            git push
+        </action>
+      </actions>
+      <on-success>Migration complete — proceed to ASSESS with the new ticket.</on-success>
+      <on-failure>Report migration failure and exit.</on-failure>
+    </phase>
+
+    <phase name="ASSESS" order="3">
       <actor>Orchestrator (reasoning tier)</actor>
       <actions>
         <action>
@@ -64,7 +125,7 @@
       <on-failure>Exit and report the assessment failure.</on-failure>
     </phase>
 
-    <phase name="ROUTE_INCOMPLETE" order="3">
+    <phase name="ROUTE_INCOMPLETE" order="4">
       <actor>Orchestrator (reasoning tier)</actor>
       <actions>
         <action>
@@ -77,7 +138,7 @@
       <on-failure>Report the failure to post questions and exit.</on-failure>
     </phase>
 
-    <phase name="ROUTE_COMPLETE" order="4">
+    <phase name="ROUTE_COMPLETE" order="5">
       <actor>Orchestrator (reasoning tier)</actor>
       <actions>
         <action>


### PR DESCRIPTION
## Summary

- **DETECT phase now scans GitHub issues** instead of beads labels. Queries `gh issue list --label "autonomously-nightly"` for open issues, picks the oldest one for processing.
- **New MIGRATE_ISSUE phase** — when a GitHub issue has no corresponding beads ticket, the system creates one (`bd create`), maps it in `.beads/github-map.json`, closes the GitHub issue with a migration comment, and commits/pushes the beads metadata.
- **Beads ticket correlation** — if a mapped beads ticket already exists in `github-map.json`, skips migration and goes straight to ASSESS.
- **autonomous-nightly behavior** updated to note that the GitHub issue number is already resolved during DETECT (with fallback to `github-map.json` search).

## Flow

```
GitHub issue with "autonomously-nightly" label
  → DETECT: find issue, check github-map.json
    → Has beads ticket? → ASSESS
    → No beads ticket? → MIGRATE_ISSUE → ASSESS
      → COMPLETE → ROUTE_COMPLETE → standard workflow (autonomous)
      → INCOMPLETE → ROUTE_INCOMPLETE → post questions, exit
```

## Test plan

- [ ] Create a GitHub issue with `autonomously-nightly` label in a consuming repo
- [ ] Run nightly — verify it finds the issue, creates a beads ticket, closes the GitHub issue
- [ ] Run nightly again with a pre-mapped ticket — verify it skips migration
- [ ] Verify ASSESS/ROUTE phases still work correctly after the phase renumbering

🤖 Generated with [Claude Code](https://claude.com/claude-code)