### PR TITLE
fix: nightly lifecycle should not close GitHub issues directly

### DIFF
--- a/.starterpack/agent_instructions/lifecycle/nightly-autonomous-run.xml
+++ b/.starterpack/agent_instructions/lifecycle/nightly-autonomous-run.xml
@@ -27,7 +27,7 @@
           |       |
           |       +~~ follow-up work found ~~> [Phase 2: MIGRATE_ISSUE] (new ticket for follow-up)
           |       |
-          |       +~~ no follow-up ~~> close issue, remove label, [EXIT — work already done]
+          |       +~~ no follow-up ~~> remove label, [EXIT — work already done]
           |
           +~~ issue found, NO beads ticket ~~> [Phase 2: MIGRATE_ISSUE]
                                                     |
@@ -89,9 +89,10 @@
         </action>
         <action>
           If NO follow-up work is found in the comments (ticket is closed, work is done):
-            Close the GitHub issue and remove the "autonomously-nightly" label:
-              gh issue close {number} --comment "Work completed in beads ticket {ticket-id}. All sub-tasks done. Closing."
+            Remove the "autonomously-nightly" label so the issue is not picked up again:
               gh issue edit {number} --remove-label "autonomously-nightly"
+            Do NOT close the GitHub issue directly — beads-sync handles issue closure
+            when the beads ticket is closed and the PR is merged.
             Report that the issue was cleaned up and exit.
         </action>
         <action>
@@ -131,8 +132,11 @@
           Use jq or python3 to safely merge the new entry into the existing JSON file.
         </action>
         <action>
-          Close the GitHub issue with a migration comment:
-            gh issue close {number} --comment "This issue is now tracked as beads ticket {ticket-id}. Work will proceed via the starterpack orchestration workflow."
+          Post a migration comment on the GitHub issue (do NOT close it — beads-sync
+          handles issue closure when the beads ticket is closed and the PR is merged):
+            gh issue comment {number} --body "This issue is now tracked as beads ticket {ticket-id}. Work will proceed via the starterpack orchestration workflow."
+          Remove the "autonomously-nightly" label since the ticket is now in beads:
+            gh issue edit {number} --remove-label "autonomously-nightly"
         </action>
         <action>
           Commit and push the beads metadata:


### PR DESCRIPTION
## Summary

- DETECT phase no longer calls `gh issue close` when a closed beads ticket has no follow-up — only removes the `autonomously-nightly` label
- MIGRATE_ISSUE phase no longer calls `gh issue close` — posts a migration comment and removes the label instead
- GitHub issue closure is handled by beads-sync when the beads ticket is closed and the PR is merged

## Problem

The nightly lifecycle was closing GitHub issues directly via `gh issue close`, bypassing the beads-sync workflow that should be the single source of truth for issue state.

## Test plan

- [ ] Nightly run with closed ticket + no follow-up → label removed, issue stays open
- [ ] Nightly run migrating new issue → comment posted, label removed, issue stays open
- [ ] Issue closes naturally when beads ticket closes and PR merges via beads-sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)