### PR TITLE
fix: nightly must never close GitHub issues directly

### DIFF
--- a/.starterpack/agent_instructions/behaviors/autonomous-nightly.xml
+++ b/.starterpack/agent_instructions/behaviors/autonomous-nightly.xml
@@ -129,6 +129,37 @@
        PR MERGE RULES
        ═══════════════════════════════════════════════════════════════════════ -->
 
+  <!-- ═══════════════════════════════════════════════════════════════════════
+       GITHUB ISSUE LIFECYCLE — HANDS OFF
+       ═══════════════════════════════════════════════════════════════════════ -->
+
+  <section name="github-issue-lifecycle">
+
+    <rule name="NEVER_CLOSE_GITHUB_ISSUES">
+      The nightly lifecycle must NEVER close GitHub issues directly via
+      "gh issue close". GitHub issue closure is handled exclusively by the
+      beads-sync workflow:
+        - On feature branches: beads-sync adds a "pending-close" label
+        - On main (after PR merge): beads-sync actually closes the issue
+
+      The only GitHub issue operations the nightly lifecycle may perform are:
+        - Reading issue content and comments (gh issue view)
+        - Posting comments (gh issue comment)
+        - Adding or removing labels (gh issue edit --add-label / --remove-label)
+        - Creating new issues (gh issue create) — only in ROUTE_INCOMPLETE fallback
+
+      This rule applies to ALL phases of the nightly lifecycle and to any
+      post-lifecycle cleanup. Do not close GitHub issues even if the beads
+      ticket is closed and all work is complete. The beads-sync workflow
+      will handle it when the PR merges to main.
+    </rule>
+
+  </section>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════
+       PR MERGE RULES
+       ═══════════════════════════════════════════════════════════════════════ -->
+
   <section name="pr-merge-rules">
 
     <rule name="DEFAULT_NO_MERGE">


### PR DESCRIPTION
## Summary

Added an explicit `NEVER_CLOSE_GITHUB_ISSUES` guardrail rule to the `autonomous-nightly` behavior. The nightly agent was closing GitHub issues directly during post-lifecycle cleanup even though the lifecycle XML didn't instruct it to.

## The problem

After the PR lifecycle completed, the agent performed a "cleanup" step calling `gh issue close` on its own. This bypasses the beads-sync workflow which is the single source of truth for GitHub issue state:
- **Feature branches**: beads-sync adds `pending-close` label
- **Main (after merge)**: beads-sync actually closes the issue

## The fix

New `github-issue-lifecycle` section in `autonomous-nightly.xml` with a `NEVER_CLOSE_GITHUB_ISSUES` rule that:
- Explicitly forbids `gh issue close` in all phases and post-lifecycle cleanup
- Lists the only permitted GitHub issue operations (view, comment, add/remove labels, create)
- Explains that beads-sync handles closure on merge to main

## Test plan

- [ ] Nightly run completes work → GitHub issue stays open with `pending-close` label
- [ ] PR merges to main → beads-sync closes the GitHub issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)