### PR TITLE
#59: Standard branch-prefix taxonomy + label overhaul (remove epics)

### DIFF
--- a/.starterpack/agent_instructions/BEHAVIORS_MANIFEST.xml
+++ b/.starterpack/agent_instructions/BEHAVIORS_MANIFEST.xml
@@ -72,7 +72,7 @@
   <behavior name="github-issues" file="behaviors/github-issues.xml">
     Authoritative reference for all GitHub issue operations: reading configuration,
     querying and creating issues, posting comments via the queue, managing labels,
-    closing issues, and detecting epic parent relationships.
+    closing issues, and resolving the base branch for multi-ticket work.
   </behavior>
 
 </behaviors-manifest>

--- a/.starterpack/agent_instructions/BEHAVIORS_MANIFEST.xml
+++ b/.starterpack/agent_instructions/BEHAVIORS_MANIFEST.xml
@@ -72,7 +72,7 @@
   <behavior name="github-issues" file="behaviors/github-issues.xml">
     Authoritative reference for all GitHub issue operations: reading configuration,
     querying and creating issues, posting comments via the queue, managing labels,
-    closing issues, and resolving the base branch for multi-ticket work.
+    and closing issues.
   </behavior>
 
 </behaviors-manifest>

--- a/.starterpack/agent_instructions/behaviors/autonomous-nightly.xml
+++ b/.starterpack/agent_instructions/behaviors/autonomous-nightly.xml
@@ -124,7 +124,7 @@
 
       GitHub issue closure is handled by the PR body:
         - PRs targeting main use "Closes #{number}" (GitHub auto-closes on merge)
-        - PRs targeting feature branches use "Relates to #{number}" (no premature closure)
+        - PRs targeting base feature branches use "Relates to #{number}" (no premature closure)
 
       The only GitHub issue operations the nightly lifecycle may perform directly are:
         - Reading issue content and comments (gh issue view, gh issue list)
@@ -182,18 +182,18 @@
   <section name="pending-close-label">
 
     <rule name="LABEL_PURPOSE">
-      The "pending-close" label signals that an epic child issue has completed work
-      merged into the epic's feature branch, but the issue cannot close yet because
+      The "pending-close" label signals that a child issue has completed work
+      merged into its base feature branch, but the issue cannot close yet because
       GitHub only auto-closes issues when a PR merges to the default branch (main).
-      The issue will auto-close when the final epic PR merges to main.
+      The issue will auto-close when the base feature branch's final PR merges to main.
     </rule>
 
     <rule name="WHEN_TO_ADD">
       Add the "pending-close" label to an issue after successfully merging a child
-      PR into an epic's feature branch (not main). Use:
+      PR into a base feature branch (not main). Use:
         gh issue edit {number} --add-label "pending-close"
       This is performed by the PR lifecycle's HANDOFF phase when the PR targets
-      a feature branch.
+      a base feature branch.
     </rule>
 
     <rule name="DETECT_SKIP">
@@ -204,9 +204,10 @@
 
     <rule name="LABEL_LIFECYCLE">
       The "pending-close" label is transient:
-      - Added: after a child PR merges to the epic's feature branch.
-      - Removed: automatically becomes irrelevant when the epic's final PR merges
-        to main and GitHub auto-closes the issue. No explicit removal is needed.
+      - Added: after a child PR merges to the base feature branch.
+      - Removed: automatically becomes irrelevant when the base feature branch's
+        final PR merges to main and GitHub auto-closes the issue. No explicit
+        removal is needed.
     </rule>
 
   </section>

--- a/.starterpack/agent_instructions/behaviors/git-conventions.xml
+++ b/.starterpack/agent_instructions/behaviors/git-conventions.xml
@@ -20,16 +20,17 @@
       The base branch determines where ticket branches are created from and where
       pull requests target:
       - "main" (default): ticket branches are created from main, PRs merge to main.
-      - A feature branch (EPIC/{number}-{desc}): created from main for multi-ticket work.
-        Ticket branches are created from the feature branch, PRs merge to the
-        feature branch. A final PR merges the feature branch to main after all
-        children complete.
+      - A base feature branch (feature/{number}-{desc}): created from main for
+        multi-ticket work, where {number} is the parent feature issue. Child ticket
+        branches are created from the base feature branch and their PRs merge into
+        it. A final PR merges the base feature branch to main after all children
+        complete.
     </rule>
 
-    <rule name="epic-closed-last">
-      The epic ticket is closed only after all children are closed. When using a
-      feature branch, the epic is closed as part of the final pull request from the
-      feature branch to main.
+    <rule name="parent-closed-last">
+      The parent feature issue is closed only after all children are closed. When
+      using a base feature branch, the parent is closed as part of the final pull
+      request from the base feature branch to main.
     </rule>
 
   </section>
@@ -49,17 +50,25 @@
     </rule>
 
     <issue-type-to-branch>
-      <type name="enhancement" branch-prefix="FEAT/" />
-      <type name="bug"     branch-prefix="BUG/" />
-      <type name="task"    branch-prefix="TASK/" />
-      <type name="chore"   branch-prefix="CHORE/" />
-      <type name="epic"    branch-prefix="EPIC/" />
+      <type name="feature"  branch-prefix="feature/"  />
+      <type name="bugfix"   branch-prefix="bugfix/"   />
+      <type name="hotfix"   branch-prefix="hotfix/"   />
+      <type name="release"  branch-prefix="release/"  />
+      <type name="chore"    branch-prefix="chore/"    />
+      <type name="docs"     branch-prefix="docs/"     />
+      <type name="refactor" branch-prefix="refactor/" />
+      <type name="test"     branch-prefix="test/"     />
+      <type name="ci"       branch-prefix="ci/"       />
+      <type name="build"    branch-prefix="build/"    />
+      <type name="perf"     branch-prefix="perf/"     />
+      <type name="style"    branch-prefix="style/"    />
+      <type name="revert"   branch-prefix="revert/"   />
     </issue-type-to-branch>
 
     <examples>
-      <example>git checkout -b FEAT/42-add-logout-button</example>
-      <example>git checkout -b BUG/57-fix-login-crash</example>
-      <example>git checkout -b EPIC/30-user-auth-overhaul</example>
+      <example>git checkout -b feature/42-add-logout-button</example>
+      <example>git checkout -b bugfix/57-fix-login-crash</example>
+      <example>git checkout -b docs/61-update-readme</example>
     </examples>
   </section>
 
@@ -88,7 +97,7 @@
   <section name="commit-discipline">
     <rule name="issue-number-prefix">
       Every commit message starts with #{number} referencing the GitHub issue
-      being worked. Always use the child issue number, not the epic number.
+      being worked. Always use the child issue number, not the parent feature issue number.
     </rule>
     <rule name="granular-commits">Commits must be granular — one logical change per commit</rule>
     <rule name="multiple-commits-expected">Multiple commits per sub-task are expected</rule>

--- a/.starterpack/agent_instructions/behaviors/git-conventions.xml
+++ b/.starterpack/agent_instructions/behaviors/git-conventions.xml
@@ -49,7 +49,7 @@
     </rule>
 
     <issue-type-to-branch>
-      <type name="feature" branch-prefix="FEAT/" />
+      <type name="enhancement" branch-prefix="FEAT/" />
       <type name="bug"     branch-prefix="BUG/" />
       <type name="task"    branch-prefix="TASK/" />
       <type name="chore"   branch-prefix="CHORE/" />

--- a/.starterpack/agent_instructions/behaviors/github-issues.xml
+++ b/.starterpack/agent_instructions/behaviors/github-issues.xml
@@ -3,7 +3,7 @@
   <summary>
     Authoritative reference for all GitHub issue operations: reading configuration,
     querying and creating issues, posting comments via the queue, managing labels,
-    closing issues, and detecting epic parent relationships.
+    closing issues, and resolving the base branch for multi-ticket work.
   </summary>
 
   <definition>
@@ -81,14 +81,6 @@
       automated processing.
     </rule>
 
-    <rule name="LIST_OPEN_EPICS">
-      To list all open epic issues (for parent detection and dependency checks):
-
-        gh issue list --label epic --state open --json number,body
-
-      Use this when determining whether a given issue is a child of an open epic.
-    </rule>
-
   </section>
 
   <!-- ═══════════════════════════════════════════════════════════════════════
@@ -97,26 +89,36 @@
 
   <section name="creating-issues">
 
-    <rule name="CREATE_EPIC">
-      To create an epic issue (a parent that groups related child issues):
+    <rule name="CREATE_PARENT_FEATURE">
+      To create a parent feature issue (a feature that groups related child issues
+      for multi-ticket work):
 
-        gh issue create --title "{title}" --body "{body}" --label epic
+        gh issue create --title "{title}" --body "{body}" --label feature
 
-      The body should include a task list of planned child issues. Epic issues use
-      the "epic" label exclusively for type identification — do not add a second
-      type label.
+      The body should include a task list of the planned child issues. The parent
+      uses the "feature" type label like any other feature; what makes it a parent
+      is the child task list in its body, not a distinct label.
     </rule>
 
     <rule name="CREATE_STANDARD_ISSUE">
-      To create a standard (non-epic) issue, use one of the issue type labels:
+      To create a standard issue, use one of the issue type labels:
 
         gh issue create --title "{title}" --body "{body}" --label {type-label}
 
       Valid type labels and their meanings:
-      - enhancement  — new feature or improvement to existing functionality
-      - bug          — something is broken or behaving incorrectly
-      - task         — a defined unit of non-feature work (migration, setup, etc.)
-      - chore        — housekeeping, dependency updates, config changes
+      - feature   — new feature or functionality
+      - bugfix    — fixing a known bug
+      - hotfix    — urgent production fix
+      - release   — release preparation
+      - chore     — maintenance, dependency updates, config changes
+      - docs      — documentation changes
+      - refactor  — code restructuring with no behavior change
+      - test      — adding or updating tests
+      - ci        — CI / pipeline configuration
+      - build     — build system or dependencies
+      - perf      — performance improvement
+      - style     — formatting / whitespace only
+      - revert    — reverting a previous change
 
       Choose the label that best describes the nature of the work. The type label
       also determines the branch name prefix used when work begins on the issue.
@@ -223,17 +225,13 @@
                  manually by humans or via gh issue edit --add-label.
 
       pending-close:
-        Purpose: Signals that an epic child issue has completed work merged into
-                 the epic's feature branch, but cannot close yet. GitHub only
-                 auto-closes issues when a PR merges to the default branch (main).
-                 Add this label after a child PR merges to a feature branch.
-                 The label becomes irrelevant once the epic's final PR merges to
-                 main and GitHub auto-closes the issue — no explicit removal needed.
-
-      epic:
-        Purpose: Marks an issue as an epic (parent of child issues). Used for
-                 filtering and branch-prefix selection. Epic branches use the
-                 EPIC/ prefix.
+        Purpose: Signals that a child issue has completed work merged into its
+                 base feature branch, but cannot close yet. GitHub only auto-closes
+                 issues when a PR merges to the default branch (main).
+                 Add this label after a child PR merges to a base feature branch.
+                 The label becomes irrelevant once the base feature branch's final
+                 PR merges to main and GitHub auto-closes the issue — no explicit
+                 removal needed.
     </rule>
 
   </section>
@@ -253,11 +251,11 @@
           Use "Closes #{number}" in the PR body.
           GitHub auto-closes the issue when the PR merges to main.
 
-      - PR targeting a feature branch (epic child work):
+      - PR targeting a base feature branch (multi-ticket child work):
           Use "Relates to #{number}" in the PR body.
           Do NOT use "Closes" — that would attempt premature closure before the
-          epic's work is complete. The issue closes when the epic's final PR
-          merges to main.
+          multi-ticket work is complete. The issue closes when the base feature
+          branch's final PR merges to main.
 
       <example>
         PR body for work targeting main:
@@ -292,54 +290,37 @@
   </section>
 
   <!-- ═══════════════════════════════════════════════════════════════════════
-       EPIC DETECTION
+       BASE BRANCH RESOLUTION
        ═══════════════════════════════════════════════════════════════════════ -->
 
-  <section name="epic-detection">
+  <section name="base-branch-resolution">
 
     <rule order="1">
-      Query all open epics:
-
-        gh issue list --label epic --state open --json number,body
-
-      Store the result for inspection. If the command returns an empty list,
-      the current issue is standalone — skip to step 4.
+      Most issues are standalone: their base branch is main. Branches are cut from
+      main and their PRs target main.
     </rule>
 
     <rule order="2">
-      For each open epic returned, inspect the epic's body for a reference to
-      the current issue number. A child reference may appear as:
-        - A task list item:   "- [ ] #42" or "- [x] #42"
-        - A numbered list:    "1. #42" or "1. Fix login crash (#42)"
-        - A prose mention:    "child of #15", "part of #15", "see #15"
-        - Any pattern where the issue number appears alongside the epic body text
-
-      If the current issue number is found in an epic's body, that epic is the
-      parent. Record the epic's issue number.
+      An issue is part of multi-ticket work when it appears as a child in a parent
+      feature issue's task list (or the human directs it). Multi-ticket work shares
+      a base feature branch (feature/{parent-number}-{desc}) cut from main, where
+      {parent-number} is the parent feature issue.
     </rule>
 
     <rule order="3">
-      If a parent epic is found, determine whether an active feature branch exists
-      for that epic. Look for a branch matching the pattern EPIC/{epic-number}-*:
+      To resolve the base branch for a child issue, look for the parent's base
+      feature branch:
 
-        git branch -r | grep "EPIC/{epic-number}-"
+        git branch -r | grep "feature/{parent-number}-"
 
-      If the feature branch exists:
-        - It becomes the mandatory base branch for the current issue's work.
-        - All branches created for the current issue must be cut from this feature
-          branch, and PRs must target it.
-        - This is not optional — epic children must use their epic's feature branch
-          as the base, not main.
-        - Log: "Issue #{current} is child of epic #{epic}, using base branch EPIC/..."
+      If it exists:
+        - It is the mandatory base branch for the child's work.
+        - All branches for the child are cut from it, and PRs target it (not main).
+        - Log: "Issue #{current} is a child of parent feature #{parent}, using base
+          branch feature/{parent-number}-..."
 
-      If no feature branch exists for the epic yet:
-        - The feature branch has not been created. Treat the current issue as if
-          no parent was found and default to main until the feature branch is set up.
-    </rule>
-
-    <rule order="4">
-      If no parent epic is found (or the epic's feature branch does not exist),
-      the issue is standalone. The base branch defaults to main.
+      If it does not exist yet, treat the child as standalone and default to main
+      until the base feature branch is created.
     </rule>
 
   </section>

--- a/.starterpack/agent_instructions/behaviors/github-issues.xml
+++ b/.starterpack/agent_instructions/behaviors/github-issues.xml
@@ -234,12 +234,6 @@
         Purpose: Marks an issue as an epic (parent of child issues). Used for
                  filtering and branch-prefix selection. Epic branches use the
                  EPIC/ prefix.
-
-      Issue type labels (used for branch naming prefix selection):
-        enhancement  → FEAT/ branch prefix
-        bug          → BUG/ branch prefix
-        task         → TASK/ branch prefix
-        chore        → CHORE/ branch prefix
     </rule>
 
   </section>

--- a/.starterpack/agent_instructions/behaviors/github-issues.xml
+++ b/.starterpack/agent_instructions/behaviors/github-issues.xml
@@ -3,7 +3,7 @@
   <summary>
     Authoritative reference for all GitHub issue operations: reading configuration,
     querying and creating issues, posting comments via the queue, managing labels,
-    closing issues, and resolving the base branch for multi-ticket work.
+    and closing issues.
   </summary>
 
   <definition>
@@ -264,7 +264,7 @@
 
           Closes #42
 
-        PR body for work targeting a feature branch:
+        PR body for work targeting a base feature branch:
           ## Summary
           Implements session clearing for the auth overhaul.
 
@@ -285,42 +285,6 @@
 
       If auto_close is false (the default), never call gh issue close — always
       close via PR body reference instead.
-    </rule>
-
-  </section>
-
-  <!-- ═══════════════════════════════════════════════════════════════════════
-       BASE BRANCH RESOLUTION
-       ═══════════════════════════════════════════════════════════════════════ -->
-
-  <section name="base-branch-resolution">
-
-    <rule order="1">
-      Most issues are standalone: their base branch is main. Branches are cut from
-      main and their PRs target main.
-    </rule>
-
-    <rule order="2">
-      An issue is part of multi-ticket work when it appears as a child in a parent
-      feature issue's task list (or the human directs it). Multi-ticket work shares
-      a base feature branch (feature/{parent-number}-{desc}) cut from main, where
-      {parent-number} is the parent feature issue.
-    </rule>
-
-    <rule order="3">
-      To resolve the base branch for a child issue, look for the parent's base
-      feature branch:
-
-        git branch -r | grep "feature/{parent-number}-"
-
-      If it exists:
-        - It is the mandatory base branch for the child's work.
-        - All branches for the child are cut from it, and PRs target it (not main).
-        - Log: "Issue #{current} is a child of parent feature #{parent}, using base
-          branch feature/{parent-number}-..."
-
-      If it does not exist yet, treat the child as standalone and default to main
-      until the base feature branch is created.
     </rule>
 
   </section>

--- a/.starterpack/agent_instructions/behaviors/human-gate.xml
+++ b/.starterpack/agent_instructions/behaviors/human-gate.xml
@@ -37,7 +37,7 @@
       <rule order="2">
         Scope — which tickets to complete autonomously:
         - Single ticket (current ticket only)
-        - All remaining tickets in the epic
+        - All remaining child tickets in the current multi-ticket work
         - Custom selection
       </rule>
       <rule order="3">

--- a/.starterpack/agent_instructions/behaviors/pr-template.xml
+++ b/.starterpack/agent_instructions/behaviors/pr-template.xml
@@ -7,7 +7,7 @@
   <template>
     ## Summary
     - 1-3 bullet points describing what changed and why
-    - Closes #{number} (if PR targets main) or Relates to #{number} (if PR targets a feature branch)
+    - Closes #{number} (if PR targets main) or Relates to #{number} (if PR targets a base feature branch)
 
     ## Changes
     | File | Change |

--- a/.starterpack/agent_instructions/lifecycle/entry.xml
+++ b/.starterpack/agent_instructions/lifecycle/entry.xml
@@ -73,16 +73,18 @@
       <!-- SPEC_FILE path -->
       <action entry="SPEC_FILE">Read the spec file in full.</action>
       <action entry="SPEC_FILE">
-        Create an epic issue: gh issue create --title "..." --body "..." --label epic
+        Create a parent feature issue: gh issue create --title "..." --body "..." --label feature
       </action>
       <action entry="SPEC_FILE">
-        Decompose the spec into individual feature/task issues.
-        For dependency tracking, add a task list in the epic body listing child issues.
+        Decompose the spec into individual child issues, each with an appropriate
+        type label. For dependency tracking, add a task list in the parent feature
+        issue body listing the child issues.
       </action>
 
       <!-- AD_HOC_REQUEST path -->
       <action entry="AD_HOC_REQUEST">
-        Create a GitHub issue: gh issue create --title "..." --body "..." --label enhancement|bug|task
+        Create a GitHub issue: gh issue create --title "..." --body "..." --label {type}
+        (where {type} is one of the issue type labels: feature, bugfix, hotfix, chore, docs, refactor, test, perf, etc.)
         Never implement an ad-hoc request without a ticket. If the human insists on skipping,
         explain that every change must be tracked and push back respectfully.
       </action>
@@ -90,25 +92,24 @@
         Confirm with the human: "Created #{number}: {title}. Proceeding."
       </action>
 
-      <!-- Epic parent detection — all paths -->
+      <!-- Base branch resolution — all paths -->
       <action>
-        Before selecting the base branch, check if this issue is a child of an open epic:
-          gh issue list --label epic --state open --json number,body
-        For each epic, check if the current issue number appears in the body
-        as a child reference (e.g., in a task list or "child of" mention).
-        If a parent epic is found:
-          - Check if a feature branch EPIC/{epic-number}-* exists for that epic.
-          - If the feature branch exists, it becomes the mandatory base branch.
-            This is not optional — epic children must target their epic's feature branch.
-          - Log: "Issue is child of epic #{N}, using feature branch EPIC/..."
-        If no parent epic is found, proceed to base branch selection as normal.
+        Before selecting the base branch, resolve whether this issue is part of
+        multi-ticket work — i.e. a child listed in a parent feature issue's task
+        list. If it is, check whether the parent's base feature branch exists:
+          git branch -r | grep "feature/{parent-number}-"
+        If the base feature branch exists, it becomes the mandatory base branch:
+        the current issue's branches are cut from it and its PR targets it.
+        Log: "Issue is child of parent feature #{N}, using base branch feature/{N}-..."
+        If there is no parent or the base feature branch does not exist yet,
+        proceed to base branch selection as normal.
       </action>
 
-      <!-- Base branch selection — all paths (skipped if epic parent detection set the base) -->
+      <!-- Base branch selection — all paths (skipped if base-branch resolution set the base) -->
       <action>
-        If no epic parent was detected, determine the base branch. Check the
+        If no base feature branch was resolved, determine the base branch. Check the
         current git context first — if already on a feature branch (e.g.
-        mid-epic work), default to that branch as the base. Otherwise,
+        mid multi-ticket work), default to that branch as the base. Otherwise,
         reason about the appropriate base:
         - If the context makes the base branch obvious, use it.
         - If ambiguous, ask the human which base branch to use (main or an
@@ -129,7 +130,7 @@
     <actions>
       <action>
         Present the full ticket breakdown to the human for approval (see human-gate behavior).
-        Include: epic issue number, all child issue numbers and titles, dependency ordering, and
+        Include: parent feature issue number, all child issue numbers and titles, dependency ordering, and
         selected base branch (main or feature branch).
       </action>
       <action>Wait for explicit human approval before proceeding.</action>
@@ -143,11 +144,11 @@
     <actor>Orchestrator launches a branch setup agent (light tier)</actor>
     <actions>
       <action>
-        If a feature branch was selected as the base branch:
-        Create the feature branch from main: git checkout -b EPIC/{number}-{desc}
+        If a base feature branch was selected as the base branch:
+        Create it from main: git checkout -b feature/{number}-{desc}
       </action>
       <action>
-        For multi-ticket work (SPEC_FILE or epic): pick the first ready child
+        For multi-ticket work (SPEC_FILE or a parent feature issue): pick the first ready child
         issue (gh issue list --state open). This child issue number becomes the
         active ticket for the PLANNING and IMPLEMENTATION phases.
       </action>

--- a/.starterpack/agent_instructions/lifecycle/nightly-autonomous-run.xml
+++ b/.starterpack/agent_instructions/lifecycle/nightly-autonomous-run.xml
@@ -55,7 +55,7 @@
         <action>
           Check if the issue has a "pending-close" label. If so, skip this issue
           and move to the next oldest — work was already completed and is waiting
-          for the epic to merge to main.
+          for the base feature branch to merge to main.
         </action>
         <action>
           Check whether an open PR already exists for this issue:
@@ -70,9 +70,9 @@
           If no open PR exists, check for merged PRs that reference this issue:
             gh pr list --search "{number}" --state merged --json number,title,url --limit 5
           If merged PRs exist, the work may already be complete:
-          - Check if the merged PR targeted a feature/epic branch (not main).
-            If so, the issue is an epic child with completed work waiting for the
-            epic to merge — skip this issue and move to the next oldest.
+          - Check if the merged PR targeted a base feature branch (not main).
+            If so, the issue is a child with completed work waiting for the base
+            feature branch to merge — skip this issue and move to the next oldest.
           - If the merged PR targeted main, the issue should already be closed
             (GitHub auto-closes on merge). If it's still open, proceed to ASSESS
             as normal (the merged PR may have been unrelated).

--- a/.starterpack/agent_instructions/lifecycle/pr.xml
+++ b/.starterpack/agent_instructions/lifecycle/pr.xml
@@ -4,7 +4,7 @@
     Creates the pull request, waits for CI checks to pass, and handles the
     next-child loop for multi-ticket work. Issue closure is handled via
     "Closes #N" in the PR body (for main-targeting PRs) or "Relates to #N"
-    (for feature-branch-targeting PRs).
+    (for base-feature-branch-targeting PRs).
   </summary>
 
   <uses-behavior name="pr-template" />
@@ -36,7 +36,7 @@
         |
         +~~ more children ~~> [PLANNING]
         |
-        +~~ feature branch done ~~> [FINAL_PR] ~~> [FINAL_CI_GATE] ~~> complete
+        +~~ base feature branch done ~~> [FINAL_PR] ~~> [FINAL_CI_GATE] ~~> complete
         |
         +~~ done ~~> complete
   -->
@@ -50,8 +50,8 @@
       <action>
         Include the appropriate issue reference in the PR body:
         - If the PR targets main: use "Closes #{number}" so GitHub auto-closes the issue on merge.
-        - If the PR targets a feature branch: use "Relates to #{number}" to avoid premature closure.
-          The final feature-branch-to-main PR will use "Closes #{number}".
+        - If the PR targets a base feature branch: use "Relates to #{number}" to avoid premature closure.
+          The final base-feature-branch-to-main PR will use "Closes #{number}".
       </action>
       <action>Push all remaining commits to remote</action>
       <action>Create the PR via "gh pr create" targeting the base branch</action>
@@ -87,19 +87,19 @@
     <actions>
       <action>Report PR URL to the human for review.</action>
       <action>
-        If the PR targeted a feature branch (not main), add the "pending-close"
+        If the PR targeted a base feature branch (not main), add the "pending-close"
         label to the issue to signal that work is complete but the issue must
-        stay open until the epic's final PR merges to main:
+        stay open until the base feature branch's final PR merges to main:
           gh issue edit {number} --add-label "pending-close"
       </action>
       <action>
-        Check for remaining open child issues (gh issue list --state open --label {epic-label}).
-        If more children exist: checkout the base branch, pick the next child
+        Check the parent feature issue's task list for remaining open child issues.
+        If more children exist: checkout the base feature branch, pick the next child
         issue, and loop to PLANNING for that child.
       </action>
       <action>
-        If all children are complete and the base branch is a feature branch:
-        proceed to FINAL_PR to merge the feature branch to main.
+        If all children are complete and the base branch is a base feature branch:
+        proceed to FINAL_PR to merge the base feature branch to main.
       </action>
       <action>
         If all children are complete and the base branch is main:
@@ -114,14 +114,15 @@
     <actor>Orchestrator launches a PR agent (reasoning tier)</actor>
     <actions>
       <action>
-        Checkout the feature branch. Run a final documentation review
-        (diff the full feature branch against main).
+        Checkout the base feature branch. Run a final documentation review
+        (diff the full base feature branch against main).
       </action>
       <action>
-        Use "Closes #{epic-number}" in the final PR body to close the epic issue on merge.
+        Use "Closes #{parent-number}" in the final PR body to close the parent
+        feature issue on merge.
       </action>
-      <action>Push the feature branch to remote</action>
-      <action>Create the final PR from the feature branch to main via "gh pr create"</action>
+      <action>Push the base feature branch to remote</action>
+      <action>Create the final PR from the base feature branch to main via "gh pr create"</action>
       <action>Report the final PR URL to the orchestrator</action>
     </actions>
     <on-success>Proceed to FINAL_CI_GATE</on-success>


### PR DESCRIPTION
## Summary

Expands the original #59 consistency fix into a full branch-prefix + label-taxonomy redesign (per discussion). Instead of papering over the `enhancement`→`FEAT/` mismatch, the type name, GitHub label, and branch prefix are now unified on the **industry-standard vocabulary** (Git Flow + Conventional Commits), and the bespoke **epic** construct is removed.

> Note: this PR is intentionally larger than issue #59's original one-line scope — we agreed to bundle the redesign here rather than open a new issue.

## Type → branch-prefix → label (now all matching)

`feature/` · `bugfix/` · `hotfix/` · `release/` · `chore/` · `docs/` · `refactor/` · `test/` · `ci/` · `build/` · `perf/` · `style/` · `revert/`

- Prefixes are lowercase full words (e.g. `feature/42-add-logout-button`), replacing `FEAT/`, `BUG/`, `TASK/`, `CHORE/`, `EPIC/`.
- Each type has a matching GitHub label (migrated out-of-band — see below).

## Epic removal

The `epic` label, `EPIC/` prefix, and parent/child auto-detection are gone. Multi-ticket work now uses a **base feature branch** (`feature/{parent}-…`) cut from main that child branches merge into, with a final PR to main. Base-branch resolution is **contextual** (the child appears in a parent feature issue's task list) rather than a label query. `pending-close` is retained and reworded for base feature branches.

## Preserved (untouched)

- Add-on labels **`autonomously-nightly`** and **`pending-close`** — the nightly workflow keys off `config.yaml → task_source.github.label`, which is unchanged.
- `config.yaml`.

## GitHub label migration (already applied)

- Renamed (preserves existing issue associations): `enhancement`→`feature`, `bug`→`bugfix`, `documentation`→`docs`.
- Created: `hotfix`, `release`, `refactor`, `test`, `ci`, `build`, `perf`, `style`, `revert`, `chore`.
- Deleted (only on closed issues): `task`, `epic`.

## Files

`git-conventions.xml`, `github-issues.xml`, `entry.xml`, `pr.xml`, `autonomous-nightly.xml`, `nightly-autonomous-run.xml`, `human-gate.xml`, `pr-template.xml`, `BEHAVIORS_MANIFEST.xml`. All XML validated well-formed.

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)
